### PR TITLE
Add readline example

### DIFF
--- a/example_project_bzl_4/readline_example_c/BUILD.bazel
+++ b/example_project_bzl_4/readline_example_c/BUILD.bazel
@@ -8,7 +8,6 @@ cc_binary(
       "*.c"
     ]),
     deps = [
-      "@readline.headers//:all",
-      "@readline.lib//:all",
+      "@readline",
     ]
 )

--- a/example_project_bzl_4/readline_example_c/BUILD.bazel
+++ b/example_project_bzl_4/readline_example_c/BUILD.bazel
@@ -1,0 +1,14 @@
+""" Hello world app """
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "main",
+    srcs = glob([
+      "*.c"
+    ]),
+    deps = [
+      "@readline.headers//:all",
+      "@readline.lib//:all",
+    ]
+)

--- a/example_project_bzl_4/readline_example_c/readline.c
+++ b/example_project_bzl_4/readline_example_c/readline.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <readline/readline.h>
+#include <readline/history.h>
+
+int main(int argc, char* argv[]) {
+  printf("Welcome! You can exit by pressing Ctrl+C at any time...\n");
+
+  if (argc > 1 && strcmp(argv[1], "-d") == 0) {
+    // By default readline does filename completion. With -d, we disable this
+    // by asking readline to just insert the TAB character itself.
+    rl_bind_key('\t', rl_insert);
+  }
+
+  char* buf;
+  while ((buf = readline(">> ")) != NULL) {
+    if (strlen(buf) > 0) {
+      add_history(buf);
+    }
+
+    printf("[%s]\n", buf);
+
+    // readline malloc's a new buffer every time.
+    free(buf);
+  }
+
+  return 0;
+}

--- a/example_project_bzl_4/third_party/dependencies.bzl
+++ b/example_project_bzl_4/third_party/dependencies.bzl
@@ -1,4 +1,6 @@
 load("@//third_party/libuv:defs.bzl", "libuv")
+load("@//third_party/ncurses:defs.bzl", "ncurses")
+load("@//third_party/readline:defs.bzl", "readline")
 load("@//third_party/xorg.libX11:defs.bzl", "libX11")
 load("@//third_party/xorg.xorgproto:defs.bzl", "xorgproto")
 
@@ -7,4 +9,6 @@ def third_party_deps():
     """Load 3rd party dependencies"""
     libuv()
     libX11()
+    ncurses()
+    readline()
     xorgproto()

--- a/example_project_bzl_4/third_party/ncurses/BUILD.bazel
+++ b/example_project_bzl_4/third_party/ncurses/BUILD.bazel
@@ -1,4 +1,5 @@
 exports_files([
     "defs.bzl",
-    "BUILD.bazel.tmpl"
+    "BUILD.bazel.tmpl",
+    "ncurses.nix",
 ])

--- a/example_project_bzl_4/third_party/ncurses/BUILD.bazel
+++ b/example_project_bzl_4/third_party/ncurses/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files([
+    "defs.bzl",
+    "BUILD.bazel.tmpl"
+])

--- a/example_project_bzl_4/third_party/ncurses/BUILD.bazel.tmpl
+++ b/example_project_bzl_4/third_party/ncurses/BUILD.bazel.tmpl
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "all",
+    srcs = glob([
+        "lib/*.a",
+        "lib/*.so*",
+    ]),
+    hdrs = glob([
+        "include/**/*.h",
+        "include/**/*.hpp",
+    ]),
+    includes = [
+        "include",
+    ],
+)

--- a/example_project_bzl_4/third_party/ncurses/BUILD.bazel.tmpl
+++ b/example_project_bzl_4/third_party/ncurses/BUILD.bazel.tmpl
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "all",
+    name = "ncurses",
     srcs = glob([
         "lib/*.a",
         "lib/*.so*",

--- a/example_project_bzl_4/third_party/ncurses/defs.bzl
+++ b/example_project_bzl_4/third_party/ncurses/defs.bzl
@@ -1,0 +1,17 @@
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load("//third_party/nix:defs.bzl", "NIX_REPOSITORIES")
+
+def ncurses():
+    nixpkgs_package(
+        name = "ncurses.headers",
+        attribute_path = "ncurses.dev",
+        build_file = "//third_party/ncurses:BUILD.bazel.tmpl",
+        repositories = NIX_REPOSITORIES,
+    )
+
+    nixpkgs_package(
+        name = "ncurses.lib",
+        attribute_path = "ncurses.out",
+        build_file = "//third_party/ncurses:BUILD.bazel.tmpl",
+        repositories = NIX_REPOSITORIES,
+    )

--- a/example_project_bzl_4/third_party/ncurses/defs.bzl
+++ b/example_project_bzl_4/third_party/ncurses/defs.bzl
@@ -3,15 +3,8 @@ load("//third_party/nix:defs.bzl", "NIX_REPOSITORIES")
 
 def ncurses():
     nixpkgs_package(
-        name = "ncurses.headers",
-        attribute_path = "ncurses.dev",
-        build_file = "//third_party/ncurses:BUILD.bazel.tmpl",
-        repositories = NIX_REPOSITORIES,
-    )
-
-    nixpkgs_package(
-        name = "ncurses.lib",
-        attribute_path = "ncurses.out",
+        name = "ncurses",
+        nix_file = "//third_party/ncurses:ncurses.nix",
         build_file = "//third_party/ncurses:BUILD.bazel.tmpl",
         repositories = NIX_REPOSITORIES,
     )

--- a/example_project_bzl_4/third_party/ncurses/ncurses.nix
+++ b/example_project_bzl_4/third_party/ncurses/ncurses.nix
@@ -1,0 +1,85 @@
+let pkgs = import <nixpkgs> {};
+    lib = pkgs.lib;
+    fetchurl = pkgs.fetchurl;
+    pkg-config = pkgs.pkg-config;
+    stdenv = pkgs.stdenv;
+    buildPackages = pkgs.buildPackages;
+
+in stdenv.mkDerivation rec {
+  # Note the revision needs to be adjusted.
+  abiVersion = "6";
+  version = "6.3";
+  name = "ncurses-${version}";
+
+  # We cannot use fetchFromGitHub (which calls fetchzip)
+  # because we need to be able to use fetchurlBoot.
+  src = let
+    # Note the version needs to be adjusted.
+    rev = "v${version}";
+  in fetchurl {
+    url = "https://github.com/mirror/ncurses/archive/${rev}.tar.gz";
+    sha256 = "1mawdjhzl2na2j0dylwc37f5w95rhgyvlwnfhww5rz2r7fgkvayv";
+  };
+
+  outputs = [ "out" ];
+  setOutputFlags = false; # some aren't supported
+
+  configureFlags = [
+    "--enable-static"
+    "--disable-shared"
+    "--without-debug"
+    "--enable-pc-files"
+    "--enable-symlinks"
+    "--with-manpage-format=normal"
+    "--disable-stripping"
+    "--without-cxx"
+    ];
+
+  depsBuildBuild = [
+    pkgs.stdenv.cc
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    buildPackages.ncurses
+  ];
+
+  preConfigure = ''
+    export PKG_CONFIG_LIBDIR="$dev/lib/pkgconfig"
+    mkdir -p "$PKG_CONFIG_LIBDIR"
+    configureFlagsArray+=(
+      "--libdir=$out/lib"
+      "--includedir=$out/include"
+      "--bindir=$out/bin"
+      "--mandir=$out/share/man"
+      "--with-pkg-config-libdir=$PKG_CONFIG_LIBDIR"
+    )
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://www.gnu.org/software/ncurses/";
+    description = "Free software emulation of curses in SVR4 and more";
+    longDescription = ''
+      The Ncurses (new curses) library is a free software emulation of curses in
+      System V Release 4.0, and more. It uses Terminfo format, supports pads and
+      color and multiple highlights and forms characters and function-key
+      mapping, and has all the other SYSV-curses enhancements over BSD Curses.
+
+      The ncurses code was developed under GNU/Linux. It has been in use for
+      some time with OpenBSD as the system curses library, and on FreeBSD and
+      NetBSD as an external package. It should port easily to any
+      ANSI/POSIX-conforming UNIX. It has even been ported to OS/2 Warp!
+    '';
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+
+  passthru = {
+    inherit abiVersion;
+  };
+}

--- a/example_project_bzl_4/third_party/ncurses/ncurses.nix
+++ b/example_project_bzl_4/third_party/ncurses/ncurses.nix
@@ -1,85 +1,25 @@
 let pkgs = import <nixpkgs> {};
     lib = pkgs.lib;
-    fetchurl = pkgs.fetchurl;
-    pkg-config = pkgs.pkg-config;
     stdenv = pkgs.stdenv;
-    buildPackages = pkgs.buildPackages;
+    ncursesStatic = pkgs.ncurses.overrideAttrs (oldAttrs: rec {
+      enableStatic = true;
 
-in stdenv.mkDerivation rec {
-  # Note the revision needs to be adjusted.
-  abiVersion = "6";
-  version = "6.3";
-  name = "ncurses-${version}";
+      configureFlags = [
+        (lib.withFeature (!enableStatic) "shared")
+        "--without-debug"
+        "--enable-pc-files"
+        "--enable-symlinks"
+        "--with-manpage-format=normal"
+        "--disable-stripping"
+      ] ++ lib.optionals stdenv.hostPlatform.isWindows [
+        "--enable-sp-funcs"
+        "--enable-term-driver"
+      ];
 
-  # We cannot use fetchFromGitHub (which calls fetchzip)
-  # because we need to be able to use fetchurlBoot.
-  src = let
-    # Note the version needs to be adjusted.
-    rev = "v${version}";
-  in fetchurl {
-    url = "https://github.com/mirror/ncurses/archive/${rev}.tar.gz";
-    sha256 = "1mawdjhzl2na2j0dylwc37f5w95rhgyvlwnfhww5rz2r7fgkvayv";
-  };
-
-  outputs = [ "out" ];
-  setOutputFlags = false; # some aren't supported
-
-  configureFlags = [
-    "--enable-static"
-    "--disable-shared"
-    "--without-debug"
-    "--enable-pc-files"
-    "--enable-symlinks"
-    "--with-manpage-format=normal"
-    "--disable-stripping"
-    "--without-cxx"
-    ];
-
-  depsBuildBuild = [
-    pkgs.stdenv.cc
-  ];
-
-  nativeBuildInputs = [
-    pkg-config
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    buildPackages.ncurses
-  ];
-
-  preConfigure = ''
-    export PKG_CONFIG_LIBDIR="$dev/lib/pkgconfig"
-    mkdir -p "$PKG_CONFIG_LIBDIR"
-    configureFlagsArray+=(
-      "--libdir=$out/lib"
-      "--includedir=$out/include"
-      "--bindir=$out/bin"
-      "--mandir=$out/share/man"
-      "--with-pkg-config-libdir=$PKG_CONFIG_LIBDIR"
-    )
-  '';
-
-  enableParallelBuilding = true;
-
-  doCheck = false;
-
-  meta = with lib; {
-    homepage = "https://www.gnu.org/software/ncurses/";
-    description = "Free software emulation of curses in SVR4 and more";
-    longDescription = ''
-      The Ncurses (new curses) library is a free software emulation of curses in
-      System V Release 4.0, and more. It uses Terminfo format, supports pads and
-      color and multiple highlights and forms characters and function-key
-      mapping, and has all the other SYSV-curses enhancements over BSD Curses.
-
-      The ncurses code was developed under GNU/Linux. It has been in use for
-      some time with OpenBSD as the system curses library, and on FreeBSD and
-      NetBSD as an external package. It should port easily to any
-      ANSI/POSIX-conforming UNIX. It has even been ported to OS/2 Warp!
-    '';
-    license = licenses.mit;
-    platforms = platforms.all;
-  };
-
-  passthru = {
-    inherit abiVersion;
-  };
+      preFixup = "";
+      postFixup = "";
+    });
+in pkgs.symlinkJoin {
+  name = "ncurses";
+  paths = [ ncursesStatic.out ncursesStatic.dev ];
 }

--- a/example_project_bzl_4/third_party/readline/BUILD.bazel
+++ b/example_project_bzl_4/third_party/readline/BUILD.bazel
@@ -1,4 +1,6 @@
 exports_files([
     "defs.bzl",
-    "BUILD.bazel.tmpl"
+    "BUILD.bazel.tmpl",
+    "readline.nix",
+    "no-arch_only.patch",
 ])

--- a/example_project_bzl_4/third_party/readline/BUILD.bazel
+++ b/example_project_bzl_4/third_party/readline/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files([
+    "defs.bzl",
+    "BUILD.bazel.tmpl"
+])

--- a/example_project_bzl_4/third_party/readline/BUILD.bazel.tmpl
+++ b/example_project_bzl_4/third_party/readline/BUILD.bazel.tmpl
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "all",
+    name = "readline",
     srcs = glob([
         "lib/*.a",
         "lib/*.so*",
@@ -16,6 +16,6 @@ cc_library(
         "include",
     ],
     deps = [
-        "@ncurses.lib//:all",
+        "@ncurses",
     ]
 )

--- a/example_project_bzl_4/third_party/readline/BUILD.bazel.tmpl
+++ b/example_project_bzl_4/third_party/readline/BUILD.bazel.tmpl
@@ -1,0 +1,21 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "all",
+    srcs = glob([
+        "lib/*.a",
+        "lib/*.so*",
+    ]),
+    hdrs = glob([
+        "include/**/*.h",
+        "include/**/*.hpp",
+    ]),
+    includes = [
+        "include",
+    ],
+    deps = [
+        "@ncurses.lib//:all",
+    ]
+)

--- a/example_project_bzl_4/third_party/readline/defs.bzl
+++ b/example_project_bzl_4/third_party/readline/defs.bzl
@@ -1,0 +1,17 @@
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+load("//third_party/nix:defs.bzl", "NIX_REPOSITORIES")
+
+def readline():
+    nixpkgs_package(
+        name = "readline.headers",
+        attribute_path = "readline81.dev",
+        build_file = "//third_party/readline:BUILD.bazel.tmpl",
+        repositories = NIX_REPOSITORIES,
+    )
+
+    nixpkgs_package(
+        name = "readline.lib",
+        attribute_path = "readline81.out",
+        build_file = "//third_party/readline:BUILD.bazel.tmpl",
+        repositories = NIX_REPOSITORIES,
+    )

--- a/example_project_bzl_4/third_party/readline/defs.bzl
+++ b/example_project_bzl_4/third_party/readline/defs.bzl
@@ -3,15 +3,11 @@ load("//third_party/nix:defs.bzl", "NIX_REPOSITORIES")
 
 def readline():
     nixpkgs_package(
-        name = "readline.headers",
-        attribute_path = "readline81.dev",
+        name = "readline",
+	nix_file = "//third_party/readline:readline.nix",
+        nix_file_deps = [
+            "//third_party/readline:no-arch_only.patch"
+        ],
         build_file = "//third_party/readline:BUILD.bazel.tmpl",
-        repositories = NIX_REPOSITORIES,
-    )
-
-    nixpkgs_package(
-        name = "readline.lib",
-        attribute_path = "readline81.out",
-        build_file = "//third_party/readline:BUILD.bazel.tmpl",
-        repositories = NIX_REPOSITORIES,
+	repositories = NIX_REPOSITORIES,
     )

--- a/example_project_bzl_4/third_party/readline/no-arch_only.patch
+++ b/example_project_bzl_4/third_party/readline/no-arch_only.patch
@@ -1,0 +1,13 @@
+diff -ru -x '*~' readline-6.3-orig/support/shobj-conf readline-6.3/support/shobj-conf
+--- support/shobj-conf	2014-02-24 03:06:29.000000000 +0100
++++ support/shobj-conf	2014-07-22 11:18:52.000000000 +0200
+@@ -194,9 +194,6 @@
+ 	# Darwin 8 == Mac OS X 10.4; Mac OS X 10.N == Darwin N+4
+ 	*)
+ 		case "${host_os}" in
+-		darwin[89]*|darwin1[012]*)
+-			SHOBJ_ARCHFLAGS='-arch_only `/usr/bin/arch`'
+-			;;
+ 		 *) 	# Mac OS X 10.9 (Mavericks) and later
+ 			SHOBJ_ARCHFLAGS=
+ 			# for 32 and 64bit universal library

--- a/example_project_bzl_4/third_party/readline/readline.nix
+++ b/example_project_bzl_4/third_party/readline/readline.nix
@@ -1,57 +1,22 @@
 let pkgs = import <nixpkgs> {};
     lib = pkgs.lib;
-    fetchurl = pkgs.fetchurl;
-    pkg-config = pkgs.pkg-config;
     stdenv = pkgs.stdenv;
-    buildPackages = pkgs.buildPackages;
+    readlineStatic = pkgs.readline81.overrideAttrs (oldAttrs: rec {
+      configureFlags = [
+        "--enable-static"
+        "--disable-shared"
+      ];
 
-in stdenv.mkDerivation rec {
-  pname = "readline";
-  version = "8.1";
+      # static build, so don't need ncurses
+      # (we also let Bazel handle the dependency)
+      propagateBuildInputs = [];
 
-  src = fetchurl {
-    url = "mirror://gnu/readline/readline-${meta.branch}.tar.gz";
-    sha256 = "00ibp0n9crbwx15k9vvckq5wsipw98b1px8pd8i34chy2gpb9kpq";
-  };
+      patches =
+        [ ./no-arch_only.patch
+        ] ++ oldAttrs.upstreamPatches;
+    });
 
-  outputs = [ "out" ];
-
-  configureFlags = [
-    "--enable-static"
-    "--disable-shared"
-    ];
-
-  patchFlags = [ "-p0" ];
-
-  patches =
-    [ ./no-arch_only.patch
-    ];
-
-  meta = with lib; {
-    description = "Library for interactive line editing";
-
-    longDescription = ''
-      The GNU Readline library provides a set of functions for use by
-      applications that allow users to edit command lines as they are
-      typed in.  Both Emacs and vi editing modes are available.  The
-      Readline library includes additional functions to maintain a
-      list of previously-entered command lines, to recall and perhaps
-      reedit those lines, and perform csh-like history expansion on
-      previous commands.
-
-      The history facilities are also placed into a separate library,
-      the History library, as part of the build process.  The History
-      library may be used without Readline in applications which
-      desire its capabilities.
-    '';
-
-    homepage = "https://savannah.gnu.org/projects/readline/";
-
-    license = licenses.gpl3Plus;
-
-    maintainers = with maintainers; [ dtzWill ];
-
-    platforms = platforms.unix;
-    branch = "8.1";
-  };
+in pkgs.symlinkJoin {
+  name = "readline";
+  paths = [ readlineStatic.out readlineStatic.dev ];
 }

--- a/example_project_bzl_4/third_party/readline/readline.nix
+++ b/example_project_bzl_4/third_party/readline/readline.nix
@@ -1,0 +1,57 @@
+let pkgs = import <nixpkgs> {};
+    lib = pkgs.lib;
+    fetchurl = pkgs.fetchurl;
+    pkg-config = pkgs.pkg-config;
+    stdenv = pkgs.stdenv;
+    buildPackages = pkgs.buildPackages;
+
+in stdenv.mkDerivation rec {
+  pname = "readline";
+  version = "8.1";
+
+  src = fetchurl {
+    url = "mirror://gnu/readline/readline-${meta.branch}.tar.gz";
+    sha256 = "00ibp0n9crbwx15k9vvckq5wsipw98b1px8pd8i34chy2gpb9kpq";
+  };
+
+  outputs = [ "out" ];
+
+  configureFlags = [
+    "--enable-static"
+    "--disable-shared"
+    ];
+
+  patchFlags = [ "-p0" ];
+
+  patches =
+    [ ./no-arch_only.patch
+    ];
+
+  meta = with lib; {
+    description = "Library for interactive line editing";
+
+    longDescription = ''
+      The GNU Readline library provides a set of functions for use by
+      applications that allow users to edit command lines as they are
+      typed in.  Both Emacs and vi editing modes are available.  The
+      Readline library includes additional functions to maintain a
+      list of previously-entered command lines, to recall and perhaps
+      reedit those lines, and perform csh-like history expansion on
+      previous commands.
+
+      The history facilities are also placed into a separate library,
+      the History library, as part of the build process.  The History
+      library may be used without Readline in applications which
+      desire its capabilities.
+    '';
+
+    homepage = "https://savannah.gnu.org/projects/readline/";
+
+    license = licenses.gpl3Plus;
+
+    maintainers = with maintainers; [ dtzWill ];
+
+    platforms = platforms.unix;
+    branch = "8.1";
+  };
+}


### PR DESCRIPTION
Although not strictly needed, pulling in the transitive ncurses
dependency too. Might be needed later when converting to static build.