### PR TITLE
Fix missing git in nix-shell setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache
 bazel-*
 .output-bazelrc
+result

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         nixUnstable
         # Dynamically load nix envs
         nix-direnv
+        # Add git client to shell, it reads host configuration
         git
       ];
       shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         nixUnstable
         # Dynamically load nix envs
         nix-direnv
+        git
       ];
       shellHook = ''
         export TERM=xterm


### PR DESCRIPTION
`git` command line is missing when initializing fresh shell via `./nix-shell`.
Credentials are auto-initiated from the host, so only thing missing is client.