### PR TITLE
Update docs to align with ADR, fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,8 @@ on:
   pull_request:
   push:
 jobs:
-  tests:
-    name: verify nix shell is properly instantiated for no pre-installed nix
+  nix-shell-check:
+    name: verify nix shell installation
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
 name: "ci-checks"
 on:
-  pull_request:
   push:
 jobs:
   nix-shell-check:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Disruptor
 ---
 [![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
+[![ci-checks](https://github.com/Qarik-Group/disruptor/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/Qarik-Group/disruptor/actions/workflows/ci.yaml)
 
 ### Example
 ```bash

--- a/docs/adrs/adr-000-using-adrs.md
+++ b/docs/adrs/adr-000-using-adrs.md
@@ -1,3 +1,5 @@
+# ADR 0: Using Architecture Decision Records
+
 ## Context
 
 Architecture for agile projects has to be described and defined differently. Not all decisions will be made at once, nor will all of them be done when the project begins.

--- a/docs/adrs/adr-001-dev-model.md
+++ b/docs/adrs/adr-001-dev-model.md
@@ -1,3 +1,5 @@
+# ADR 1: Head-to-head development model
+
 ## Context
 
 There are many approaches to structuring work of project versioning, development, testing and deployment. As everyone could have different experience and implicit expectations for said workflow, a common vision for how to approach that process is needed (otherwise, we would risk the repository becoming an unruly stitching of contradictory ideas). 

--- a/docs/adrs/adr-002-deps-mngmt.md
+++ b/docs/adrs/adr-002-deps-mngmt.md
@@ -1,3 +1,5 @@
+# ADR 2: Dependecy management using Nix package manager
+
 ## Context
 
 Ideally all developers working on a project should never fall into the pitfall of "it works on my machine" - the tools they are using, its configuration should be identical all across the systems, resulting in reproducible artifacts and behaviours, from the dev hosts up to "production environments". 

--- a/docs/adrs/adr-NNN-desc.md.template
+++ b/docs/adrs/adr-NNN-desc.md.template
@@ -1,3 +1,5 @@
+# Title
+
 ## Context
 
 This section describes the forces at play, including technological, political, social, and project local. These forces are probably in tension, and should be called out as such. The language in this section is value-neutral. It is simply describing facts.

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
         nixUnstable
         # Dynamically load nix envs
         nix-direnv
-        # Add git client to shell, it reads host configuration
         git
       ];
       shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         nixUnstable
         # Dynamically load nix envs
         nix-direnv
+        # Add git client to shell, it reads host configuration
         git
       ];
       shellHook = ''


### PR DESCRIPTION
Bundle of small changes:
- fix CI to not run twice for PR's
- shorten the name of CI step used to verify nix shell - it is not fitting into the GitHub UI
- add titles for all ADR's - to follow the form of the linked ADR templates by Michael Nygard https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md