### PR TITLE
Nix shell improvements

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,14 +34,25 @@
       ];
       shellHook = ''
         export TERM=xterm
-        export DIRENV_CONFIG=$(pwd)/.cache
-        export NIX_USER_CONF_FILES=${./scripts/nix.conf}
+        # nix-shell --keep will refuse to retain a variable,
+        # which is not exported in user shell, but which is 
+        # set in the nix-shell.sh. 
+        # Working around this issue takes a lot of effort
+        # (detecting export, exporting and undoing exports
+        # on shell closure).
+        # This approach is more naive, but less
+        # maintainance intensive.
+        export DIRENV_CONFIG="$(pwd)/.cache"
+        export NIX_CONF_DIR="$(pwd)/scripts"
+        export NIX_USER_CONF_FILES=""
+        export NIX_PATH="nixpkgs=$(pwd)/scripts/nixpkgs.nix"
         . ${pkgs.nix-direnv}/share/nix-direnv/direnvrc
         eval "$(direnv hook bash)"
       '';
       TMPDIR = "/tmp";
     };
   in {
+      nixpkgs = pkgs;
       # DO NOT USE nix develop, as it is not hermetic
       # use nix-shell --pure, which loads devShell with out any settings from user env
       devShell = dev_shell;

--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,0 +1,12 @@
+{ system ? builtins.currentSystem, ... }@args:
+
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ../flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ../.; }
+).defaultNix.outputs.nixpkgs.${system}

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -148,8 +148,10 @@ ensure_direnv_is_configured() {
   local readonly project_root
   project_root=$(dirname "$(realpath "${__DIR__}"/../docs)")
   mkdir -p "${CACHE_ROOT}"
-  echo "[whitelist]" > "${NIX_DIRENV_CONF_PATH}"
-  echo "prefix = [ \"${project_root}\" ]" >> "${NIX_DIRENV_CONF_PATH}"
+  cat > "${DIRENV_CONF_PATH}" << EOF
+[whitelist]
+prefix = [ "${project_root}" ]
+EOF
 }
 
 ensure_nix_is_present() {
@@ -208,14 +210,13 @@ ensure_nix_is_present
 ensure_direnv_is_configured
 
 if ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
-  NIX_USER_CONF_FILES=${NIX_EXTRA_CONF_PATH}\
    nix-shell --pure "${__DIR__}/shell.nix" "$@"
 else
   # Explicitly source nix profile in bash invocation
   # In future: remove dependency on user HOME
   # shellcheck disable=SC2250
   $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash -c\
-    ". ${HOME}/.nix-profile/etc/profile.d/nix.sh\
+    ". ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh\
       && NIX_CONF_DIR=${NIX_CONF_DIR}\
       NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}\
       NIX_PATH=${NIX_PATH}\

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -54,8 +54,11 @@ readonly NIX_USER_CHROOT_BIN="${NIX_USER_CHROOT_DIR}/nix-user-chroot"
 readonly NIX_STORE="${CACHE_ROOT}/nix-store"
 readonly NIX_VERSION="2.5.1"
 readonly NIX_INSTALL_SCRIPT="${CACHE_ROOT}/nix-${NIX_VERSION}-install.sh"
-readonly NIX_EXTRA_CONF_PATH="${__DIR__}/nix.conf"
-readonly NIX_DIRENV_CONF_PATH="${CACHE_ROOT}/direnv.toml"
+readonly NIX_CONF_DIR="${__DIR__}"
+readonly NIX_USER_CONF_FILES=''
+readonly DIRENV_CONFIG="${CACHE_ROOT}"
+readonly DIRENV_CONF_PATH="${DIRENV_CONFIG}/direnv.toml"
+readonly NIX_PATH="nixpkgs=${__DIR__}/nixpkgs.nix"
 
 IS_NIX_INSTALLED=false
 
@@ -135,9 +138,10 @@ setup_nix() {
   # shellcheck disable=SC2250
   $NIX_USER_CHROOT_BIN "${NIX_STORE}" sh -c\
    "curl -L https://releases.nixos.org/nix/nix-${NIX_VERSION}/install > ${NIX_INSTALL_SCRIPT} && sh ${NIX_INSTALL_SCRIPT}\
+    --no-channel-add\
     --no-daemon\
     --no-modify-profile\
-    --nix-extra-conf-file ${NIX_EXTRA_CONF_PATH}"
+    --nix-extra-conf-file ${NIX_CONF_DIR}/nix.conf"
 }
 
 ensure_direnv_is_configured() {
@@ -211,7 +215,10 @@ else
   # In future: remove dependency on user HOME
   # shellcheck disable=SC2250
   $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash -c\
-    ". ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh\
-      && NIX_USER_CONF_FILES=${NIX_EXTRA_CONF_PATH}\
+    ". ${HOME}/.nix-profile/etc/profile.d/nix.sh\
+      && NIX_CONF_DIR=${NIX_CONF_DIR}\
+      NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}\
+      NIX_PATH=${NIX_PATH}\
       nix-shell --pure '${__DIR__}/shell.nix'" "$@"
 fi
+

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -28,11 +28,11 @@ realpath () {
 {
   # Double quoting breaks desired behaviour
   # shellcheck disable=SC2086
-  __FILE__=$(dirname "$(realpath $0)")
+  __DIR__=$(dirname "$(realpath $0)")
 } || {
   echo "Unable to determine current script location.."
   echo "Will assume '.'"
-  __FILE__="."
+  __DIR__="."
 }
 
 fail() {
@@ -47,14 +47,14 @@ require_util() {
 }
 
 readonly USER_HOME="${HOME:-"HOME variable has not been set"}"
-readonly CACHE_ROOT="${__FILE__}/../.cache"
+readonly CACHE_ROOT="${__DIR__}/../.cache"
 readonly NIX_USER_CHROOT_VERSION="1.2.2"
 readonly NIX_USER_CHROOT_DIR="${CACHE_ROOT}/nix-user-chroot"
 readonly NIX_USER_CHROOT_BIN="${NIX_USER_CHROOT_DIR}/nix-user-chroot"
 readonly NIX_STORE="${CACHE_ROOT}/nix-store"
 readonly NIX_VERSION="2.5.1"
 readonly NIX_INSTALL_SCRIPT="${CACHE_ROOT}/nix-${NIX_VERSION}-install.sh"
-readonly NIX_EXTRA_CONF_PATH="${__FILE__}/nix.conf"
+readonly NIX_EXTRA_CONF_PATH="${__DIR__}/nix.conf"
 readonly NIX_DIRENV_CONF_PATH="${CACHE_ROOT}/direnv.toml"
 
 IS_NIX_INSTALLED=false
@@ -142,7 +142,7 @@ setup_nix() {
 
 ensure_direnv_is_configured() {
   local readonly project_root
-  project_root=$(dirname "$(realpath "${__FILE__}"/../docs)")
+  project_root=$(dirname "$(realpath "${__DIR__}"/../docs)")
   mkdir -p "${CACHE_ROOT}"
   echo "[whitelist]" > "${NIX_DIRENV_CONF_PATH}"
   echo "prefix = [ \"${project_root}\" ]" >> "${NIX_DIRENV_CONF_PATH}"
@@ -205,7 +205,7 @@ ensure_direnv_is_configured
 
 if ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
   NIX_USER_CONF_FILES=${NIX_EXTRA_CONF_PATH}\
-   nix-shell --pure "${__FILE__}/shell.nix" "$@"
+   nix-shell --pure "${__DIR__}/shell.nix" "$@"
 else
   # Explicitly source nix profile in bash invocation
   # In future: remove dependency on user HOME
@@ -213,5 +213,5 @@ else
   $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash -c\
     ". ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh\
       && NIX_USER_CONF_FILES=${NIX_EXTRA_CONF_PATH}\
-      nix-shell --pure '${__FILE__}/shell.nix'" "$@"
+      nix-shell --pure '${__DIR__}/shell.nix'" "$@"
 fi


### PR DESCRIPTION
This change attempts to resolve the issue of various 'hick-ups' happening if the nix-shell.sh is run on NixOS or machine with previous nix installation.

For example: "error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)"

Additionally: rename dumbly named __FILE__ variable. 