### PR TITLE
Introduce --vanilla mode which spawns impure shell with default settings

### DIFF
--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Build all
         # See: https://github.com/Qarik-Group/disruptor/issues/20
         # Tl;dr direnv hook not triggering, resulting in manual need to invoke nix-shell
-        run: ./nix-shell.sh --run 'cd example_project_bzl_4 && nix-shell --run "bazel build //..."'
+        run: ./nix-shell.sh -- --run 'cd example_project_bzl_4 && nix-shell --run "bazel build //..."'

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -13,7 +13,7 @@ jobs:
        # Flakes do not like shallow clones
       with:
         fetch-depth: 0
-    - run: ./nix-shell.sh --run 'nix --version'
+    - run: ./nix-shell.sh -- --run 'nix --version'
   nix-shell-check:
     name: lint shell scripts
     runs-on: ubuntu-latest

--- a/example_project_bzl_4/shell.nix
+++ b/example_project_bzl_4/shell.nix
@@ -2,15 +2,9 @@
 { system ? builtins.currentSystem, ... }:
 
 let
-  flakes-lock = builtins.fromJSON (builtins.readFile ../flake.lock);
-  pkgs-manifest = flakes-lock.nodes.nixpkgs.locked;
-  pkgs-source = builtins.fetchTarball {
-    url =
-      "https://github.com/${pkgs-manifest.owner}/${pkgs-manifest.repo}/archive/${pkgs-manifest.rev}.tar.gz";
-    sha256 =
-      (builtins.replaceStrings [ "sha256-" ] [ "" ] pkgs-manifest.narHash);
-  };
-  pkgs = import pkgs-source {
+  # As NIX_PATH is tightly controlled,
+  # using <> import is not breaking hermeticity.
+  pkgs = import <nixpkgs> {
     inherit system;
   };
 in pkgs.stdenv.mkDerivation {

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -222,6 +222,7 @@ ensure_nix_is_present() {
 }
 
 ensure_vanilla_rc_exists() {
+  mkdir -p "${CACHE_ROOT}"
   cat > "${VANILLA_RC}" << EOF
 . ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh
 export NIX_CONF_DIR=${NIX_CONF_DIR}

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -162,7 +162,7 @@ setup_nix() {
 
 ensure_direnv_is_configured() {
   local readonly project_root
-  project_root=$(dirname "$(realpath "${__DIR__}"/../docs)")
+  project_root=$(dirname "$(realpath "${__DIR__}"/..)")
   mkdir -p "${CACHE_ROOT}"
   cat > "${DIRENV_CONF_PATH}" << EOF
 [whitelist]

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -47,7 +47,6 @@ require_util() {
 }
 
 readonly USER_HOME="${HOME:-"HOME variable has not been set"}"
-readonly USER_NAME="${USER:-"USER variable has not been set"}"
 readonly CACHE_ROOT="${__DIR__}/../.cache"
 readonly NIX_USER_CHROOT_VERSION="1.2.2"
 readonly NIX_USER_CHROOT_DIR="${CACHE_ROOT}/nix-user-chroot"
@@ -226,9 +225,7 @@ ensure_vanilla_rc_exists() {
   cat > "${VANILLA_RC}" << EOF
 . ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh
 export NIX_CONF_DIR=${NIX_CONF_DIR}
-nix-channel --add https://nixos.org/channels/nixos-21.11 nixos
-nix-channel --update
-export NIX_PATH=${USER_HOME}/.nix-defexpr/channels:nixpkgs=/nix/var/nix/profiles/per-user/${USER_NAME}/channels/nixos
+export NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-21.11.tar.gz"
 EOF
 }
 

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -99,7 +99,7 @@ preflightCheck() {
 
 printHelp() {
   cat << EOF
-   Usage: nix-shell.sh [--vanilla] [--help]
+   Usage: nix-shell.sh [--vanilla] [--help] -- <PARAMS TO PASS TO NIX-SHELL>
 
    optional arguments:
      -h, --help           print this message and exit


### PR DESCRIPTION
This change aims to make it possible to run disruptors project without dropping into nix-shell.sh, possibly overriding some dependencies