### PR TITLE
Aligned flake/vanilla shell entrypoints

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,40 +16,8 @@
   let
     pkgs = nixpkgs.legacyPackages.${system};
     pkgs_latest = nixpkgs.legacyPackages.${system};
-    dev_shell = pkgs.stdenv.mkDerivation {
-      name = "dev-shell";
-      buildInputs = with pkgs; [
-        cacert
-        coreutils-full
-        curlFull
-        direnv
-        # Add git client to shell, it reads host configuration
-        git
-        gnutar
-        # Nix 2.5 (as the one from the installator)
-        nixUnstable
-        # Dynamically load nix envs
-        nix-direnv
-        shellcheck
-      ];
-      shellHook = ''
-        export TERM=xterm
-        # nix-shell --keep will refuse to retain a variable,
-        # which is not exported in user shell, but which is 
-        # set in the nix-shell.sh. 
-        # Working around this issue takes a lot of effort
-        # (detecting export, exporting and undoing exports
-        # on shell closure).
-        # This approach is more naive, but less
-        # maintainance intensive.
-        export DIRENV_CONFIG="$(pwd)/.cache"
-        export NIX_CONF_DIR="$(pwd)/scripts"
-        export NIX_USER_CONF_FILES=""
-        export NIX_PATH="nixpkgs=$(pwd)/scripts/nixpkgs.nix"
-        . ${pkgs.nix-direnv}/share/nix-direnv/direnvrc
-        eval "$(direnv hook bash)"
-      '';
-      TMPDIR = "/tmp";
+    dev_shell = import ./shell.nix {
+      pkgs = nixpkgs.legacyPackages.${system};
     };
   in {
       nixpkgs = pkgs;

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -1,10 +1,48 @@
-(import
-  (
-    let lock = builtins.fromJSON (builtins.readFile ../flake.lock); in
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-      sha256 = lock.nodes.flake-compat.locked.narHash;
-    }
-  )
-  { src = ../.; }
-).shellNix
+{ pkgs ? import <nixpkgs> { } }:
+with builtins;
+let
+  PWD = getEnv "PWD";
+  setIfEmpty = name: default:
+    if getEnv name == ""
+    then default
+    else getEnv name;
+
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    cacert
+    coreutils-full
+    curlFull
+    direnv
+    # Add git client to shell, it reads host configuration
+    git
+    gnutar
+    # Nix 2.5 (as the one from the installator)
+    nixUnstable
+    # Dynamically load nix envs
+    nix-direnv
+    shellcheck
+  ];
+
+
+  # nix-shell --keep will refuse to retain a variable,
+  # which is not exported in user shell, but which is
+  # set in the nix-shell.sh.
+  # Working around this issue takes a lot of effort
+  # (detecting export, exporting and undoing exports
+  # on shell closure).
+  # This approach is more naive, but less
+  # maintainance intensive.
+  DIRENV_CONFIG = setIfEmpty "DIRENV_CONFIG" "${PWD}/.cache";
+  NIX_CONF_DIR = setIfEmpty "NIX_CONF_DIR" "${PWD}/scripts";
+  NIX_PATH = setIfEmpty "NIX_PATH" "nixpkgs=${PWD}/scripts/nixpkgs.nix";
+  NIX_USER_CONF_FILES = "";
+  TERM = "xterm";
+  TMPDIR = "/tmp";
+
+  shellHook = ''
+    . ${pkgs.nix-direnv}/share/nix-direnv/direnvrc
+    eval "$(direnv hook bash)"
+  '';
+}
+

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -225,7 +225,7 @@ ensure_nix_shell_rc_exists() {
   cat > "${NIX_SHELL_RC}" << EOF
 
 $(
-  if ! ${IS_NIXOS} || ! ${IS_NIX_INSTALLED}; then
+  if ! ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
     echo ". ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh";
     echo "export NIX_CONF_DIR=${NIX_CONF_DIR}";
     echo "export NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}";

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -59,7 +59,7 @@ readonly NIX_USER_CONF_FILES=''
 readonly DIRENV_CONFIG="${CACHE_ROOT}"
 readonly DIRENV_CONF_PATH="${DIRENV_CONFIG}/direnv.toml"
 readonly NIX_PATH="nixpkgs=${__DIR__}/nixpkgs.nix"
-readonly VANILLA_RC="${CACHE_ROOT}/vanilla.rc"
+readonly NIX_SHELL_RC="${CACHE_ROOT}/nix_shell.rc"
 
 IS_NIX_INSTALLED=false
 VANILLA_RUN=false
@@ -220,12 +220,25 @@ ensure_nix_is_present() {
   setup_nix
 }
 
-ensure_vanilla_rc_exists() {
+ensure_nix_shell_rc_exists() {
   mkdir -p "${CACHE_ROOT}"
-  cat > "${VANILLA_RC}" << EOF
-. ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh
-export NIX_CONF_DIR=${NIX_CONF_DIR}
-export NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-21.11.tar.gz"
+  cat > "${NIX_SHELL_RC}" << EOF
+
+$(
+  if ! ${IS_NIXOS} || ! ${IS_NIX_INSTALLED}; then
+    echo ". ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh";
+    echo "export NIX_CONF_DIR=${NIX_CONF_DIR}";
+    echo "export NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}";
+  fi
+
+  if ${VANILLA_RUN}; then
+    echo "export NIX_PATH=\
+nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-21.11.tar.gz";
+  else
+    echo "export NIX_PATH=${NIX_PATH}";
+  fi
+)
+
 EOF
 }
 
@@ -267,27 +280,16 @@ while true; do
   esac
 done
 
-ensure_vanilla_rc_exists
 ensure_nix_is_present
 ensure_direnv_is_configured
+ensure_nix_shell_rc_exists
 
 if ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
-  exec ${SHELL} -ci "nix-shell --pure '${__DIR__}/shell.nix' ${NIX_SHELL_ARGS}"
-elif ${VANILLA_RUN}; then
-  # Explicitly source nix profile in bash invocation
-  # In future: remove dependency on user HOME
-  # shellcheck disable=SC2250
-  exec $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash \
-    --rcfile "${VANILLA_RC}" \
+  exec ${SHELL} --rcfile "${NIX_SHELL_RC}"\
     -ci "nix-shell --pure '${__DIR__}/shell.nix' ${NIX_SHELL_ARGS}"
 else
   # shellcheck disable=SC2250
-  exec $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash \
-    --rcfile "${USER_HOME}/.nix-profile/etc/profile.d/nix.sh" \
-    -ci "\
-      NIX_CONF_DIR=${NIX_CONF_DIR}\
-      NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}\
-      NIX_PATH=${NIX_PATH}\
-      nix-shell --pure '${__DIR__}/shell.nix' ${NIX_SHELL_ARGS}"
+  exec $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash --rcfile "${NIX_SHELL_RC}"\
+    -ci "nix-shell --pure '${__DIR__}/shell.nix' ${NIX_SHELL_ARGS}"
 fi
 


### PR DESCRIPTION
This change fixes some of differences between "vanilla" and "flake" based shells.

- Moved `mkShell` definition to `scripts/shell.nix`, so that `vanilla` shell won't load `nixpkgs` from `flake.lock` but use channel provided by `nix-shell.sh`
- Changed environment variable(s) re-exports in `shell.nix` to take into account values which may already be set by `nix-shell.sh`.
- Sanitized parsing of additional arguments for `nix-shell`
- Added dynamically generated rcfile shared across all shell invocations