### PR TITLE
Enable impure shell

### DIFF
--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,0 +1,41 @@
+# (C) Martin V\"ath <martin@mvath.de>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# shellcheck disable=SC1000-SC2500
+Push() {
+	case $1 in
+	-c)
+		PushA_=
+		shift;;
+	*)
+		eval PushA_=\$$1;;
+	esac
+	PushB_=$1
+	shift
+	for PushE_
+	do	[ -z "${PushA_:++}" ] || PushA_="$PushA_ "
+		unset PushF_
+		case ${PushE_:-=} in
+		[=~]*)
+			PushF_=false;;
+		esac
+		PushC_=$PushE_
+		while PushD_=${PushC_%%\'*}
+		do	if ${PushF_-:} && case $PushD_ in
+			*[!-+=~@%/:.,_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ]*)
+				false;;
+			esac
+			then	PushA_=$PushA_$PushD_
+			else	PushA_="$PushA_'$PushD_'"
+				unset PushF_
+			fi
+			[ x"$PushD_" = x"$PushC_" ] && break || \
+			PushA_=$PushA_\\\'
+			PushC_=${PushC_#*\'}
+		done
+	done
+	eval "$PushB_=\$PushA_
+	unset PushA_ PushB_ PushC_ PushD_ PushE_
+	[ -n \"\${$PushB_:++}\" ]" || return 1
+}
+

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -1,13 +1,4 @@
 { pkgs ? import <nixpkgs> { } }:
-with builtins;
-let
-  PWD = getEnv "PWD";
-  setIfEmpty = name: default:
-    if getEnv name == ""
-    then default
-    else getEnv name;
-
-in
 pkgs.mkShell {
   buildInputs = with pkgs; [
     cacert
@@ -24,23 +15,11 @@ pkgs.mkShell {
     shellcheck
   ];
 
-
-  # nix-shell --keep will refuse to retain a variable,
-  # which is not exported in user shell, but which is
-  # set in the nix-shell.sh.
-  # Working around this issue takes a lot of effort
-  # (detecting export, exporting and undoing exports
-  # on shell closure).
-  # This approach is more naive, but less
-  # maintainance intensive.
-  DIRENV_CONFIG = setIfEmpty "DIRENV_CONFIG" "${PWD}/.cache";
-  NIX_CONF_DIR = setIfEmpty "NIX_CONF_DIR" "${PWD}/scripts";
-  NIX_PATH = setIfEmpty "NIX_PATH" "nixpkgs=${PWD}/scripts/nixpkgs.nix";
-  NIX_USER_CONF_FILES = "";
   TERM = "xterm";
   TMPDIR = "/tmp";
 
   shellHook = ''
+    set -a; . ${builtins.getEnv "NIX_SHELL_RC"}; set +a
     . ${pkgs.nix-direnv}/share/nix-direnv/direnvrc
     eval "$(direnv hook bash)"
     cd() { builtin cd $1; eval "$(direnv export bash)"; }

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -227,16 +227,16 @@ ensure_nix_shell_rc_exists() {
 
     set +u
     if
-      [ -n "${NIX_PATH}" ];
-    then
-      local nix_path="${NIX_PATH}"
-    elif
       # shellcheck disable=SC1090
       [ -n "${EXTRA_RC}" ]\
       && nix_path_in_rc="$(. "${EXTRA_RC}"; echo "${NIX_PATH}")"\
       && [ -n "${nix_path_in_rc}" ];
     then
       local nix_path="${nix_path_in_rc}"
+    elif
+      [ -n "${NIX_PATH}" ];
+    then
+      local nix_path="${NIX_PATH}"
     else
       fail "NIX_PATH undefined"
     fi

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -47,6 +47,7 @@ require_util() {
 }
 
 readonly USER_HOME="${HOME:-"HOME variable has not been set"}"
+readonly DEFAULT_NIX_PATH="nixpkgs=${__DIR__}/nixpkgs.nix"
 readonly CACHE_ROOT="${__DIR__}/../.cache"
 readonly NIX_USER_CHROOT_VERSION="1.2.2"
 readonly NIX_USER_CHROOT_DIR="${CACHE_ROOT}/nix-user-chroot"
@@ -58,7 +59,6 @@ readonly NIX_CONF_DIR="${__DIR__}"
 readonly NIX_USER_CONF_FILES=''
 readonly DIRENV_CONFIG="${CACHE_ROOT}"
 readonly DIRENV_CONF_PATH="${DIRENV_CONFIG}/direnv.toml"
-readonly NIX_PATH="nixpkgs=${__DIR__}/nixpkgs.nix"
 readonly NIX_SHELL_RC="${CACHE_ROOT}/nix_shell.rc"
 
 IS_NIX_INSTALLED=false
@@ -221,34 +221,37 @@ ensure_nix_is_present() {
 }
 
 ensure_nix_shell_rc_exists() {
-  mkdir -p "${CACHE_ROOT}"
-  cat > "${NIX_SHELL_RC}" << EOF
-
-$(
-  if ! ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
-    echo ". ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh";
-    echo "export NIX_CONF_DIR=${NIX_CONF_DIR}";
-    echo "export NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}";
-  fi
-
   if ${VANILLA_RUN}; then
-    echo "export NIX_PATH=\
-nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-21.11.tar.gz";
+    set +u
+    if [ -n "${NIX_PATH}" ]; then
+      local nix_path="${NIX_PATH}"
+    else
+       fail "NIX_PATH undefined"
+    fi
+    set -u
   else
-    echo "export NIX_PATH=${NIX_PATH}";
+    local nix_path="${DEFAULT_NIX_PATH}"
   fi
-)
 
-EOF
+  mkdir -p "${CACHE_ROOT}"
+
+  cat > "${NIX_SHELL_RC}" <<- EOL
+	NIX_PATH=${nix_path}
+	EOL
+
+  if ! ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
+     cat >> "${NIX_SHELL_RC}" <<-EOL
+	. ${USER_HOME}/.nix-profile/etc/profile.d/nix.sh
+	NIX_CONF_DIR=${NIX_CONF_DIR}
+	NIX_USER_CONF_FILES=${NIX_USER_CONF_FILES}
+	EOL
+  fi
 }
 
 preflightCheck
 
 # Parse script input params
 OPTS=$(getopt -o "hv" --long "help,vanilla" -n "$(basename "$0")" -- "$@")
-
-# Store nix-shell input params
-NIX_SHELL_ARGS=''
 
 # shellcheck disable=SC2181
 if [ $? != 0 ] ; then
@@ -269,9 +272,6 @@ while true; do
       ;;
     -- )
       shift
-      # Pass arguments to nix-shell preserving quotes
-      # Do not rely on shell's builtin printf as it may lack some of directives
-      NIX_SHELL_ARGS=$(/usr/bin/env printf '%q ' "$@")
       break
       ;;
     * )
@@ -284,12 +284,23 @@ ensure_nix_is_present
 ensure_direnv_is_configured
 ensure_nix_shell_rc_exists
 
-if ${IS_NIXOS} || ${IS_NIX_INSTALLED}; then
-  exec ${SHELL} --rcfile "${NIX_SHELL_RC}"\
-    -ci "nix-shell --pure '${__DIR__}/shell.nix' ${NIX_SHELL_ARGS}"
-else
+if ! ${IS_NIXOS} && ! ${IS_NIX_INSTALLED}; then
   # shellcheck disable=SC2250
-  exec $NIX_USER_CHROOT_BIN "${NIX_STORE}" bash --rcfile "${NIX_SHELL_RC}"\
-    -ci "nix-shell --pure '${__DIR__}/shell.nix' ${NIX_SHELL_ARGS}"
+  SHELL="$NIX_USER_CHROOT_BIN ${NIX_STORE} bash"
 fi
+
+# Pass arguments to nix-shell preserving quotes
+nsargs="$( (set -o xtrace;: "$@") 2>&1 )"
+nsargs=${nsargs#+++ :}
+nsargs=${nsargs#++ :}
+nsargs=${nsargs#+ :}
+if ! ${VANILLA_RUN}; then
+  nsargs="--pure ${nsargs}"
+fi
+
+# shellcheck disable=SC2086
+exec ${SHELL}\
+  -ci "\
+  set -a ; . ${NIX_SHELL_RC}; set +a ;\
+  nix-shell '${__DIR__}/shell.nix' ${nsargs}"
 

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -284,21 +284,22 @@ ensure_nix_is_present
 ensure_direnv_is_configured
 ensure_nix_shell_rc_exists
 
+# shellcheck disable=SC1091
+. "${__DIR__}/push.sh"
+
 if ! ${IS_NIXOS} && ! ${IS_NIX_INSTALLED}; then
   # shellcheck disable=SC2250
   SHELL="$NIX_USER_CHROOT_BIN ${NIX_STORE} bash"
 fi
 
 # Pass arguments to nix-shell preserving quotes
-nsargs="$( (set -o xtrace;: "$@") 2>&1 )"
-nsargs=${nsargs#+++ :}
-nsargs=${nsargs#++ :}
-nsargs=${nsargs#+ :}
-if ! ${VANILLA_RUN}; then
-  nsargs="--pure ${nsargs}"
+if ${VANILLA_RUN}; then
+  Push -c nsargs "$@" || true
+else
+  Push -c nsargs --pure "$@"
 fi
 
-# shellcheck disable=SC2086
+# shellcheck disable=SC2086,SC2154
 exec ${SHELL}\
   -ci "\
   set -a ; . ${NIX_SHELL_RC}; set +a ;\

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -236,6 +236,8 @@ ensure_nix_shell_rc_exists() {
   mkdir -p "${CACHE_ROOT}"
 
   cat > "${NIX_SHELL_RC}" <<- EOL
+	DIRENV_CONFIG=${DIRENV_CONFIG}
+	NIX_SHELL_RC=${NIX_SHELL_RC}
 	NIX_PATH=${nix_path}
 	EOL
 


### PR DESCRIPTION
This change enables impure shell, removes hardcoded dependency on nixpkgs channel and fixes some of compatibliity issues.

You can verify it by running:
```
./nix-shell.sh -- --run 'env | grep NIX_PATH'
./nix-shell.sh --vanilla -- --run 'env | grep NIX_PATH'
NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-21.11.tar.gz ./nix-shell.sh --vanilla -- --run 'env | grep NIX_PATH'
```

Fixes: #28 
Fixes: #29 
Fixes: #30 