### PR TITLE
Run bazel build inside nix-shell on different os'es

### DIFF
--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -18,7 +18,7 @@ jobs:
           # Flakes do not like shallow clones
         with:
           fetch-depth: 0
-      # Mandatory to install 'coreutils' on MacOS
+        # Mandatory to install 'coreutils' on MacOS
       - name: Install dependencies on macOS
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -7,7 +7,10 @@ on:
 jobs:
   full-build:
     name: build example_project_bzl_4
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15 ]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses:

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -23,6 +23,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install coreutils
+          sh <(curl -L https://nixos.org/nix/install)
       - name: Install nix-shell
         run: ./nix-shell.sh
       - name: Build all

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -24,8 +24,8 @@ jobs:
         run: |
           brew install coreutils
           sh <(curl -L https://nixos.org/nix/install)
-          nix-shell -p nix-info --run "nix-info -m"
           source ~/.profile
+          nix-shell -p nix-info --run "nix-info -m"
       - name: Install nix-shell
         run: ./nix-shell.sh
       - name: Build all

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -18,6 +18,11 @@ jobs:
           # Flakes do not like shallow clones
         with:
           fetch-depth: 0
+      # Mandatory to install 'coreutils' on MacOS
+      - name: Install dependencies on macOS
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install coreutils
       - name: Install nix-shell
         run: ./nix-shell.sh
       - name: Build all

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -24,6 +24,8 @@ jobs:
         run: |
           brew install coreutils
           sh <(curl -L https://nixos.org/nix/install)
+          nix-shell -p nix-info --run "nix-info -m"
+          source ~/.profile
       - name: Install nix-shell
         run: ./nix-shell.sh
       - name: Build all

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -23,10 +23,5 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install coreutils
-          sh <(curl -L https://nixos.org/nix/install)
-          source ~/.profile
-          nix-shell -p nix-info --run "nix-info -m"
-      - name: Install nix-shell
-        run: ./nix-shell.sh
       - name: Build all
         run: ./nix-shell.sh -- --run 'cd example_project_bzl_4; bazel build //...'

--- a/.github/workflows/ci-example-project.yaml
+++ b/.github/workflows/ci-example-project.yaml
@@ -19,9 +19,14 @@ jobs:
         with:
           fetch-depth: 0
         # Mandatory to install 'coreutils' on MacOS
-      - name: Install dependencies on macOS
+      - name: Install coreutils on macOS
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install coreutils
+      - name: Install nix on macOS
+        if: startsWith(matrix.os, 'macos')
+        uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Build all
         run: ./nix-shell.sh -- --run 'cd example_project_bzl_4; bazel build //...'

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -86,7 +86,7 @@ preflightCheck() {
   require_util tar "decompress nix installation package"
   case "$(uname)" in
     Darwin)
-      require_util nix "make the magic happen. You are running on OSX, please make sure Nix is installed by running the following: sh <(curl -L https://nixos.org/nix/install)."
+      #require_util nix "make the magic happen. You are running on OSX, please make sure Nix is installed by running the following: sh <(curl -L https://nixos.org/nix/install)."
     ;;
     Linux)
       require_util unshare "verify kernel support for user namespaces"

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -86,7 +86,7 @@ preflightCheck() {
   require_util tar "decompress nix installation package"
   case "$(uname)" in
     Darwin)
-      #require_util nix "make the magic happen. You are running on OSX, please make sure Nix is installed by running the following: sh <(curl -L https://nixos.org/nix/install)."
+      require_util nix "make the magic happen. You are running on OSX, please make sure Nix is installed by running the following: sh <(curl -L https://nixos.org/nix/install)."
     ;;
     Linux)
       require_util unshare "verify kernel support for user namespaces"


### PR DESCRIPTION
Add matrix for the job that runs `bazel build //...` to check on compatibility between platforms.