### PR TITLE
setup DRY shells by nesting direnv-loaded environments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+nix_direnv_watch_file flake.lock flake.nix
+nix_direnv_watch_file scripts/nixpkgs-latest.nix scripts/nixpkgs.nix
+nix_direnv_watch_file scripts/shell.nix 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
         "type": "github"
       },
       "original": {
@@ -31,6 +31,29 @@
         "type": "github"
       }
     },
+    "nix-direnv": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647945652,
+        "narHash": "sha256-ZWUxjEuScdbZkWLo79/ojRhsxTejJIgLpovoiNAI8XU=",
+        "owner": "nix-community",
+        "repo": "nix-direnv",
+        "rev": "7c41549bd4a1f16a5ecbf027c42dff07ac402a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-direnv",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1647992509,
@@ -49,11 +72,11 @@
     },
     "nixpkgs_latest": {
       "locked": {
-        "lastModified": 1647893727,
-        "narHash": "sha256-pOi7VdCb+s5Cwh5CS7YEZVRgH9uCmE87J5W7iXv29Ck=",
+        "lastModified": 1648069223,
+        "narHash": "sha256-BXzQV8p/RR440EB9qY0ULYfTH0zSW1stjUCYeP4SF+E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ec61dd4167f04be8d05c45780818826132eea0d",
+        "rev": "1d08ea2bd83abef174fb43cbfb8a856b8ef2ce26",
         "type": "github"
       },
       "original": {
@@ -67,6 +90,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "nix-direnv": "nix-direnv",
         "nixpkgs": "nixpkgs",
         "nixpkgs_latest": "nixpkgs_latest"
       }

--- a/projects/.envrc
+++ b/projects/.envrc
@@ -1,2 +1,1 @@
 source_up
-use nix

--- a/projects/bzl4/shell.nix
+++ b/projects/bzl4/shell.nix
@@ -1,28 +1,14 @@
-
-{ system ? builtins.currentSystem, ... }:
-
-let
-  # As NIX_PATH is tightly controlled,
-  # using <> import is not breaking hermeticity.
-  pkgs = import <nixpkgs> {
-    inherit system;
-  };
-in pkgs.stdenv.mkDerivation {
-  name = "example-project-bzl-4-shell";
+{
+   system ? builtins.currentSystem
+ , pkgs ? import <nixpkgs> { inherit system; }
+}:
+pkgs.mkShell {
   buildInputs = with pkgs; [
-    cacert
-    coreutils-full
-    curlFull
-    direnv
-    gnutar
-    nixUnstable
     bazel_4
     bazel-buildtools
   ];
   shellHook = ''
-    export TERM=xterm
     # readlink as absolute path is needed
     echo "startup --output_base $(readlink -f ./bazel-output)" > "$(pwd)"/.output-bazelrc
   '';
-  TMPDIR = "/tmp";
 }

--- a/projects/bzl5_bzlmod/.envrc
+++ b/projects/bzl5_bzlmod/.envrc
@@ -1,1 +1,2 @@
+source_up
 use nix

--- a/projects/bzl5_bzlmod/shell.nix
+++ b/projects/bzl5_bzlmod/shell.nix
@@ -1,32 +1,16 @@
-
-{ system ? builtins.currentSystem, ... }:
-
-let
-  # As NIX_PATH is tightly controlled,
-  # using <> import is not breaking hermeticity.
-  pkgs = import <nixpkgs> {
-    inherit system;
-  };
-  pkgs_latest = import <nixpkgs_latest> {
-    inherit system;
-  };
-in pkgs.stdenv.mkDerivation {
-  name = "bzl-5-shell";
+{
+   system ? builtins.currentSystem
+ , pkgs ? import <nixpkgs> { inherit system; }
+ , pkgs_latest ? import <nixpkgs_latest> { inherit system; }
+}:
+pkgs.mkShell {
   buildInputs = with pkgs; [
-    cacert
-    coreutils-full
-    curlFull
-    direnv
-    gnutar
-    nixUnstable
     pkgs_latest.bazel_5
     pkgs_latest.bazel-buildtools
     jdk11
   ];
   shellHook = ''
-    export TERM=xterm
     # readlink as absolute path is needed
     echo "startup --output_base $(readlink -f ./bazel-output)" > "$(pwd)"/.output-bazelrc
   '';
-  TMPDIR = "/tmp";
 }

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -10,8 +10,6 @@ pkgs.mkShell {
     gnutar
     # Nix 2.5 (as the one from the installator)
     nixUnstable
-    # Dynamically load nix envs
-    nix-direnv
     shellcheck
   ];
 
@@ -20,7 +18,7 @@ pkgs.mkShell {
 
   shellHook = ''
     set -a; . ${builtins.getEnv "NIX_SHELL_RC"}; set +a
-    . ${pkgs.nix-direnv}/share/nix-direnv/direnvrc
+    cat ${pkgs.nix-direnv}/share/nix-direnv/direnvrc > ''${DIRENV_CONFIG}/direnvrc
     eval "$(direnv hook bash)"
     cd() { builtin cd $1; eval "$(direnv export bash)"; }
   '';


### PR DESCRIPTION
This PR fixes nix-direnv import, and removes duplicated parts of shell definitions by nesting direnv environments.

Note. This set-up is not fully "DRY". Additional work is needed to trigger direnv reloads when a change to any of *.nix files inputs change.