### PR TITLE
Fix shell.sh to include nix.conf for nixos users, update latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
     },
     "nixpkgs_latest": {
       "locked": {
-        "lastModified": 1648069223,
-        "narHash": "sha256-BXzQV8p/RR440EB9qY0ULYfTH0zSW1stjUCYeP4SF+E=",
+        "lastModified": 1650161686,
+        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d08ea2bd83abef174fb43cbfb8a856b8ef2ce26",
+        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
         "type": "github"
       },
       "original": {

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -239,6 +239,7 @@ ensure_nix_shell_rc_exists() {
   cat >> "${NIX_SHELL_RC}" <<- EOL
 	DIRENV_CONFIG=${DIRENV_CONFIG}
 	NIX_SHELL_RC=${NIX_SHELL_RC}
+  NIX_CONF_DIR=${NIX_CONF_DIR}
 	EOL
 
 }


### PR DESCRIPTION
On the nixos users can't just run shell and execute `nix flake update` or `nix flake lock`.
+ Update to the nixpkgs_latest so we can access newest packages like `bazel_5` which brings `5.1.1` version of Bazel vs `5.0.0`.