### PR TITLE
Provide the compiler as part of the platform

### DIFF
--- a/projects/bzl4/.bazelrc
+++ b/projects/bzl4/.bazelrc
@@ -3,3 +3,40 @@ build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 
 # Enable platforms for cc_rules
 build --incompatible_enable_cc_toolchain_resolution
+
+build --experimental_platform_in_output_dir
+
+# Build with gcc9 by default
+build --platforms=//platforms:x86_64_linux_gcc9
+# Config for gcc11
+build:gcc11 --platforms=//platforms:x86_64_linux_gcc11
+# Config for cuda
+build:cuda --//hello_world:gpu=cuda
+
+# config for BES
+build:bes --bes_results_url=https://buildbuddy.1e100.one/invocation/
+build:bes --bes_backend=grpcs://buildbuddy-grpc.1e100.one
+build:bes --noslim_profile
+build:bes --experimental_profile_include_target_label
+build:bes --experimental_profile_include_primary_output
+build:bes --build_metadata=USER=dev
+
+# Config for remote cache, also uses BES
+build:cache --config=bes
+build:cache --remote_cache=grpcs://buildbuddy-grpc.1e100.one
+build:cache --remote_timeout=3600
+
+# Config for remote execution, also uses remote cache and BES
+build:remote --config=cache
+build:remote --experimental_repo_remote_exec
+build:remote --remote_executor=grpcs://buildbuddy-grpc.1e100.one
+build:remote --extra_execution_platforms=@buildbuddy_toolchain//:platform
+build:remote --crosstool_top=@buildbuddy_toolchain//:toolchain
+build:remote --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain
+build:remote --javabase=@buildbuddy_toolchain//:javabase_jdk8
+build:remote --host_javabase=@buildbuddy_toolchain//:javabase_jdk8
+build:remote --java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
+build:remote --host_java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
+build:remote --define=EXECUTOR=remote
+
+try-import %workspace%/user.bazelrc

--- a/projects/bzl4/WORKSPACE
+++ b/projects/bzl4/WORKSPACE
@@ -22,9 +22,9 @@ http_archive(
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    sha256 = "7efb0f82cda5cdaa8e96b687734c5704b91353561d7889e5d84a13b6d30f4cb8",
-    strip_prefix = "rules_nixpkgs-05a445575de51872f528c537cc7ff3ab11114f21",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/05a445575de51872f528c537cc7ff3ab11114f21.tar.gz"],
+    sha256 = "17abb7a7ee9630d86ce297998a118ff7258dea627d21559cdf9f6cf618f817d2",
+    strip_prefix = "rules_nixpkgs-d542df716db422f6a7fab180202d03e1f1cc03f6",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/d542df716db422f6a7fab180202d03e1f1cc03f6.tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")

--- a/projects/bzl4/WORKSPACE
+++ b/projects/bzl4/WORKSPACE
@@ -27,6 +27,21 @@ http_archive(
     urls = ["https://github.com/tweag/rules_nixpkgs/archive/d542df716db422f6a7fab180202d03e1f1cc03f6.tar.gz"],
 )
 
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
+    strip_prefix = "buildbuddy-toolchain-829c8a574f706de5c96c54ca310f139f4acda7dd",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/829c8a574f706de5c96c54ca310f139f4acda7dd.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")
+
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
 rules_nixpkgs_dependencies()
 

--- a/projects/bzl4/WORKSPACE
+++ b/projects/bzl4/WORKSPACE
@@ -53,3 +53,16 @@ cpp_toolchains()
 
 load("//third_party:dependencies.bzl", "third_party_deps")
 third_party_deps()
+
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+    ],
+    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/projects/bzl4/hello_world/BUILD.bazel
+++ b/projects/bzl4/hello_world/BUILD.bazel
@@ -2,6 +2,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
 cc_binary(
     name = "main",
@@ -43,3 +44,24 @@ config_setting(
 #         "define": "with_cuda=1",
 #     },
 # )
+
+pkg_tar(
+    name = "debian-data",
+    srcs = [
+        ":main",
+    ],
+)
+
+pkg_deb(
+    name = "hello-world-deb",
+    architecture = "amd64",
+    built_using = "bazel 5.3.2",
+    data = ":debian-data",
+    depends = [
+      "xz",
+    ],
+    description = "description",
+    maintainer = "The Qarik authors <user@mail.com>",
+    package = "hello-world",
+    version = "1.0.0",
+)

--- a/projects/bzl4/hello_world/BUILD.bazel
+++ b/projects/bzl4/hello_world/BUILD.bazel
@@ -1,6 +1,7 @@
 """ Hello world app """
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 cc_binary(
     name = "main",
@@ -9,5 +10,36 @@ cc_binary(
     ]),
     deps = [
       "//third_party/xz"
-    ]
+    ],
+    defines = select({
+      ":cuda_build": ["WITH_CUDA"],
+       "//conditions:default": [],
+    })
 )
+
+string_flag(
+    name = "gpu",
+    build_setting_default = "none",
+    values = [
+      "none",
+      "cuda"
+    ],
+)
+
+
+config_setting(
+    name = "cuda_build",
+    flag_values = {
+        ":gpu": "cuda",
+    },
+    visibility = ["//visibility:public"],
+)
+
+
+# Legacy way for configurable build attributes
+# config_setting(
+#     name = "cuda_build",
+#     values = {
+#         "define": "with_cuda=1",
+#     },
+# )

--- a/projects/bzl4/hello_world/main.cpp
+++ b/projects/bzl4/hello_world/main.cpp
@@ -2,6 +2,9 @@
 #include <lzma.h>
 
 int main() {
-  std::cout << "Hello World!";
+  std::cout << "Hey there!\n";
+  #ifndef WITH_CUDA
+  std::cout << "I'm missing my cuda\n";
+  #endif
   return 0;
 }

--- a/projects/bzl4/platforms/BUILD.bazel
+++ b/projects/bzl4/platforms/BUILD.bazel
@@ -1,8 +1,40 @@
+constraint_setting(name = "gcc")
+
+constraint_value(
+    name = "gcc9",
+    constraint_setting = ":gcc",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "gcc11",
+    constraint_setting = ":gcc",
+    visibility = ["//visibility:public"],
+)
+
 platform(
     name = "x86_64_linux",
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "x86_64_linux_gcc9",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        ":gcc9",
+    ],
+)
+
+platform(
+    name = "x86_64_linux_gcc11",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        ":gcc11",
     ],
 )
 

--- a/projects/bzl4/third_party/cpp_toolchains/defs.bzl
+++ b/projects/bzl4/third_party/cpp_toolchains/defs.bzl
@@ -11,8 +11,10 @@ def cpp_toolchains():
     # for example unknown and pc are interchangeable.
 
     nixpkgs_cc_configure(
-        name = "cpp-toolchain-x86_64-linux",
+        name = "cpp-toolchain-x86_64-linux-gcc11",
         repositories = NIX_REPOSITORIES,
+        attribute_path = "gcc11",
+        nix_file_content = "import <nixpkgs> {}",
         exec_constraints = [
             "@platforms//cpu:x86_64",
             "@platforms//os:linux",
@@ -20,6 +22,23 @@ def cpp_toolchains():
         target_constraints = [
             "@platforms//cpu:x86_64",
             "@platforms//os:linux",
+            "@//platforms:gcc11",
+        ],
+    )
+
+    nixpkgs_cc_configure(
+        name = "cpp-toolchain-x86_64-linux-gcc9",
+        repositories = NIX_REPOSITORIES,
+        attribute_path = "gcc9",
+        nix_file_content = "import <nixpkgs> {}",
+        exec_constraints = [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+        ],
+        target_constraints = [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//platforms:gcc9",
         ],
     )
 


### PR DESCRIPTION
An alternative way of switching gcc versions using different platforms compared to https://github.com/Qarik-Group/disruptor/pull/53. This variant can benefit from `--experimental_platform_in_output_dir`.