### PR TITLE
Fix broken rules_java module for bzlmod project by upgrading Bazel

### DIFF
--- a/.github/workflows/ci-bzl-projects.yaml
+++ b/.github/workflows/ci-bzl-projects.yaml
@@ -9,7 +9,7 @@ jobs:
     name: build ${{ matrix.project }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-18.04, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15 ]
         project: [ bzl4, bzl5_bzlmod ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-bzl-projects.yaml
+++ b/.github/workflows/ci-bzl-projects.yaml
@@ -9,7 +9,7 @@ jobs:
     name: build ${{ matrix.project }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15 ]
+        os: [ ubuntu-latest, ubuntu-18.04, macos-latest ]
         project: [ bzl4, bzl5_bzlmod ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,26 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -41,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655029160,
-        "narHash": "sha256-pcb9mmnZycMYgWmuF6tD7mi5eNW4eDfY1PjVx/J9ebE=",
+        "lastModified": 1675592206,
+        "narHash": "sha256-hLmVU5hqsR/byJS/Oofq54buh1GEwFeYsKbug0ILyaA=",
         "owner": "nix-community",
         "repo": "nix-direnv",
-        "rev": "83fc6d34718f3e5df677206ccbb7e9b59838970a",
+        "rev": "75c74a090bf37f34cd92eeab7f22f17dc0fcd48f",
         "type": "github"
       },
       "original": {
@@ -56,16 +71,17 @@
     },
     "nixgl": {
       "inputs": {
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1654775507,
-        "narHash": "sha256-NPkQiaz6Oo5EuWj5hRXMKebAhAfiVtnklii0imR85dE=",
+        "lastModified": 1672992692,
+        "narHash": "sha256-/eLQLSNIa22ARTZbk+x8i0iE8khe1eiHWkuxgTVXZ7g=",
         "owner": "guibou",
         "repo": "nixGL",
-        "rev": "1cce2dd704829504d057dacc71daf1c00951460d",
+        "rev": "643e730efb981ffaf8478f441ec9b9aeea1c89f5",
         "type": "github"
       },
       "original": {
@@ -76,27 +92,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655278232,
-        "narHash": "sha256-H6s7tnHYiDKFCcLADS4sl1sUq0dDJuRQXCieguk/6SA=",
+        "lastModified": 1675918889,
+        "narHash": "sha256-hy7re4F9AEQqwZxubct7jBRos6md26bmxnCjxf5utJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b538fcb329a7bc3d153962f17c509ee49166973",
+        "rev": "49efda9011e8cdcd6c1aad30384cb1dc230c82fe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_latest": {
       "locked": {
-        "lastModified": 1655221618,
-        "narHash": "sha256-ht8HRFthDKzYt+il+sGgkBwrv+Ex2l8jdGVpsrPfFME=",
+        "lastModified": 1675942811,
+        "narHash": "sha256-/v4Z9mJmADTpXrdIlAjFa1e+gkpIIROR670UVDQFwIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6616de389ed55fba6eeba60377fc04732d5a207c",
+        "rev": "724bfc0892363087709bd3a5a1666296759154b1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
       url = github:edolstra/flake-compat;
       flake = false;
     };
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     nixpkgs_latest.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-direnv.url = "github:nix-community/nix-direnv";
     nix-direnv.inputs = {

--- a/projects/bzl5_bzlmod/MODULE.bazel
+++ b/projects/bzl5_bzlmod/MODULE.bazel
@@ -4,6 +4,6 @@ module(
 )
 
 bazel_dep(name = "rules_java", version = "5.4.0")
-bazel_dep(name = "common-module", version = "1.0.0")
+bazel_dep(name = "common-module", version = "1.1.0")
 
 local_path_override(module_name = "common-module", path = "modules/common_module")

--- a/projects/bzl5_bzlmod/MODULE.bazel
+++ b/projects/bzl5_bzlmod/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.1",
 )
 
-bazel_dep(name = "rules_java", version = "5.0.0")
+bazel_dep(name = "rules_java", version = "5.4.0")
 bazel_dep(name = "common-module", version = "1.0.0")
 
 local_path_override(module_name = "common-module", path = "modules/common_module")

--- a/projects/bzl5_bzlmod/modules/common_module/MODULE.bazel
+++ b/projects/bzl5_bzlmod/modules/common_module/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "common-module",
-    version = "1.0.0",
+    version = "1.1.0",
 )
 
-bazel_dep(name = "rules_java", version = "5.0.0")
+bazel_dep(name = "rules_java", version = "5.4.0")

--- a/projects/bzl5_bzlmod/shell.nix
+++ b/projects/bzl5_bzlmod/shell.nix
@@ -5,8 +5,8 @@
 }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    pkgs_latest.bazel_5
-    pkgs_latest.bazel-buildtools
+    bazel_6
+    bazel-buildtools
     jdk11
   ];
   shellHook = ''


### PR DESCRIPTION
Looks like the current setup of Bazel 5 with rules_java 5.0.0 is broken, failing as Bazel can't find `register_toolchains` method inside rules_java module.

Fix is to upgrade to Bazel 6 where bzlmod is no longer experimental and rules_java looks more stable.

Root cause was probably some push over semVer in rules_java that removed API on module side.